### PR TITLE
IsInstance can be also a tuple or string of types

### DIFF
--- a/fudge/inspector.py
+++ b/fudge/inspector.py
@@ -585,7 +585,10 @@ class IsInstance(ValueTest):
         return isinstance(other, self.cls)
 
     def _repr_argspec(self):
-        return self._make_argspec(repr(self.cls.__name__))
+        if isinstance(self.cls, (tuple, list)):
+            return self._make_argspec(repr(self.cls))
+        else:
+            return self._make_argspec(repr(self.cls.__name__))
 
 class NotValue(ValueTest):
     def __init__(self, item):


### PR DESCRIPTION
IsInstance can also be a tuple or list of types (same as in Python). this works until an error needs to be printed an in that case the code will break. 
This should fix that.