### PR TITLE
Inform build environment of setuptools requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = 'setuptools.build_meta'
+requires = ["setuptools>=45,<58"]

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ assert version
 extra_setup = {}
 if sys.version_info >= (3,):
     extra_setup['use_2to3'] = True
+    # use_2to3 removed in setuptools v58
+    extra_setup['setup_requires']=['setuptools<58'],
     # extra_setup['use_2to3_fixers'] = ['your.fixers']
 
 setup(


### PR DESCRIPTION
setuptools v58 removed use_2to3 which is required to build this project for Python 3.x setups. In order for this package to be installable by modern package build setups, we need to inform the handler that this version is required.

A pyproject.toml has also been added, to inform PEP 518 builders about our setuptools version requirement.

See https://github.com/pypa/setuptools/issues/2086
Fixes #13